### PR TITLE
CMake: Also search in `/usr/rose` for rose

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ CHiLL is a source-to-source translator for composing high level loop transformat
 
 ### Install Prerequisites
 
-1. Install [a boost version for Rose](install-boost).
-2. Install [Rose](install-rose).
+1. Install [a boost version for Rose](https://github.com/CtopCsUtahEdu/chill/wiki/Install-Boost).
+2. Install [Rose](https://github.com/CtopCsUtahEdu/chill/wiki/Install-Rose).
 3. Install isl from repository. [optional but recomended]
-4. Install [IEGenLib](install-iegenlib)
+4. Install [IEGenLib](https://github.com/CtopCsUtahEdu/chill/wiki/Install-IEGenLib)
 
 ### Build CHiLL
 

--- a/cmake/FindRose.cmake
+++ b/cmake/FindRose.cmake
@@ -13,13 +13,13 @@ endif()
 
 find_path(Rose_INCLUDE_DIR rose/rose.h
     HINTS ${ROSEHOME} ${CHILLENV}
-    PATHS /usr
+    PATHS /usr /usr/rose
     PATH_SUFFIXES include) # This ONLY includes the include dir
 
 MACRO(FIND_AND_ADD_Rose_LIB _libname_)
     find_library(Rose_${_libname_}_LIB ${_libname_}
         HINTS ${ROSEHOME} ${CHILLENV}
-        PATHS /usr
+        PATHS /usr /usr/rose
         PATH_SUFFIXES lib)
     if (Rose_${_libname_}_LIB)
         set(Rose_LIBS ${Rose_LIBS} ${Rose_${_libname_}_LIB})


### PR DESCRIPTION
When installing ROSE from their PPA (for Ubuntu; [see here][1]), it's installed to
`/usr/rose`.  I successfully compiled CHiLL by modifying
`FindRose.cmake` and the ROSE compiler was found.

[1]: https://github.com/rose-compiler/rose/wiki/How-to-Set-Up-ROSE